### PR TITLE
Using a rest endpoint for the async processor

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -12,8 +12,8 @@ DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
 SKIP_DB_CREATE=${6-false}
 
-WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
-WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wpqt/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-/tmp/wpqt/wordpress/}
 
 download() {
     if [ `which curl` ]; then

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace WPQueueTasks;
+
+/**
+ * Class Handler - Sets up the REST api endpoint for handling async requests
+ *
+ * @package WPQueueTasks
+ */
+class Handler {
+
+	/**
+	 * Stores the namespace that the REST route should live under
+	 */
+	const API_NAMESPACE = 'wpqt/v1';
+
+	/**
+	 * Stores the name of the endpoint
+	 */
+	const ENDPOINT_RUN = 'queue';
+
+	/**
+	 * Sets up the REST handler
+	 */
+	public function setup() {
+
+		// Registers the rest endpoint to handle async processing
+		add_action( 'rest_api_init', [ $this, 'register_rest_endpoint' ] );
+	}
+
+	/**
+	 * Register the rest endpoint for async processing
+	 *
+	 * @access public
+	 * @return void
+	 */
+	public function register_rest_endpoint() {
+
+		register_rest_route(
+			self::API_NAMESPACE, '/' . self::ENDPOINT_RUN . '/(?P<queue>[\w]+)', [
+				'methods'             => 'PUT',
+				'callback'            => [ $this, 'run_queue_processor' ],
+				'permission_callback' => [ $this, 'check_rest_permissions' ],
+				'show_in_index'       => false,
+			]
+		);
+
+	}
+
+	/**
+	 * Runs the processor within the REST endpoint when you hit it
+	 *
+	 * @param \WP_REST_Request $request The incoming request object
+	 *
+	 * @return \WP_Error|\WP_REST_Response
+	 * @access public
+	 */
+	public function run_queue_processor( $request ) {
+
+		$queue_name = ( isset( $request['queue'] ) ) ? $request['queue'] : '';
+		$body = json_decode( $request->get_body(), true );
+		$term_id = ( ! empty( $body['term_id'] ) ) ? absint( $body['term_id'] ) : 0;
+
+		if ( empty( $queue_name ) || empty( $term_id ) ) {
+			return rest_ensure_response(
+				new \WP_Error( 'rest-queue-invalid', __( 'No queue name or ID passed', 'wp-queue-tasks' ) )
+			);
+		}
+
+		do_action( 'wpqt_run_processor', $queue_name, $term_id );
+
+		return rest_ensure_response( sprintf( __( '%s queue processed', 'wp-queue-tasks' ), $queue_name ) );
+
+	}
+
+	/**
+	 * Validates the defined secret so script kiddies aren't hitting our endpoint over and over
+	 *
+	 * @param \WP_REST_Request $request The incoming request object
+	 *
+	 * @return bool|\WP_Error
+	 * @access public
+	 */
+	public function check_rest_permissions( $request ) {
+
+		$body = json_decode( $request->get_body(), true );
+
+		if (
+			! defined( 'WPQT_PROCESSOR_SECRET' ) ||
+			! isset( $body['secret'] ) ||
+			! hash_equals( WPQT_PROCESSOR_SECRET, $body['secret'] )
+		) {
+			return new \WP_Error( 'no-secret', __( 'Secret must be defined and passed to the request for the processor to run', 'wp-queue-tasks' ) );
+		}
+
+		return true;
+
+	}
+
+}

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -35,43 +35,7 @@ class Processor {
 	 * Sets up all of the actions we need for the class
 	 */
 	public function setup() {
-		add_action( 'init', [ $this, 'setup_processing' ] );
 		add_action( 'wpqt_run_processor', [ $this, 'run_processor' ], 10, 2 );
-	}
-
-	/**
-	 * Sets up the handlers for each of the queues
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function setup_processing() {
-
-		global $wpqt_queues;
-
-		if ( ! empty( $wpqt_queues ) && is_array( $wpqt_queues ) ) {
-			foreach ( $wpqt_queues as $queue_name => $queue_args ) {
-				if ( 'async' === $queue_args->processor ) {
-					add_action( 'admin_post_nopriv_wpqt_process_' . $queue_name, [ $this, 'process_queue' ] );
-				}
-			}
-		}
-	}
-
-	/**
-	 * Handles the incoming async post request, and creates the hook for running the processor
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function process_queue() {
-
-		// Accept some data from the request
-		$queue_name = empty( $_POST['queue_name'] ) ? '' : $_POST['queue_name'];
-		$term_id = empty( $_POST['term_id'] ) ? 0 : $_POST['term_id'];
-
-		do_action( 'wpqt_run_processor', $queue_name, $term_id );
-
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,7 +7,7 @@
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 if ( ! $_tests_dir ) {
-	$_tests_dir = '/tmp/wordpress-tests-lib';
+	$_tests_dir = '/tmp/wpqt/wordpress-tests-lib';
 }
 
 // Give access to tests_add_filter() function.

--- a/tests/src/test-Handler.php
+++ b/tests/src/test-Handler.php
@@ -1,0 +1,169 @@
+<?php
+
+use WPQueueTasks\Handler;
+
+class TestHandler extends WP_UnitTestCase {
+
+	public function setUp() {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server;
+		$this->server   = $wp_rest_server;
+		do_action( 'rest_api_init' );
+
+		$this->secret = 'thisismysecret';
+		if ( ! defined( 'WPQT_PROCESSOR_SECRET' ) ) {
+			define( 'WPQT_PROCESSOR_SECRET', $this->secret );
+		}
+	}
+
+	public function tearDown() {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test to make sure that the callback to setup the REST endpoint gets added to the correct hook
+	 */
+	public function testRestRegistration() {
+
+		$handler_obj = new Handler();
+		$handler_obj->setup();
+
+		$this->assertEquals( 10, has_action( 'rest_api_init', [ $handler_obj, 'register_rest_endpoint' ] ) );
+
+	}
+
+	/**
+	 * Test that the endpoint gets registered correctly
+	 */
+	public function testEndpointRegistered() {
+
+		$handler_obj = new Handler();
+		$handler_obj->register_rest_endpoint();
+		$endpoint = '/' . Handler::API_NAMESPACE . '/' . Handler::ENDPOINT_RUN . '/(?P<queue>[\w]+)';
+
+		$this->assertTrue( isset( $this->server->get_routes()[ $endpoint ] ) );
+		$this->assertTrue( isset( $this->server->get_routes()[ '/' . Handler::API_NAMESPACE ] ) );
+
+	}
+
+	/**
+	 * Test that our route throws a 404 if we hit it with the wrong request method
+	 */
+	public function testInvalidRequest() {
+
+		$handler_obj = new Handler();
+		$handler_obj->register_rest_endpoint();
+
+		$request = new \WP_REST_Request( 'GET', '/' . Handler::API_NAMESPACE . '/' . Handler::ENDPOINT_RUN . '/test' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 404, $response->data['data']['status'] );
+	}
+
+	/**
+	 * Test to make sure auth fails if we don't pass it the proper secret
+	 */
+	public function testAuthFailure() {
+
+		$handler_obj = new Handler();
+		$handler_obj->register_rest_endpoint();
+
+		$request = new WP_REST_Request( 'PUT', '/' . Handler::API_NAMESPACE . '/' . Handler::ENDPOINT_RUN . '/test' );
+		$request->set_body(
+			wp_json_encode( [
+				'secret' => 'somefakesecret',
+			] )
+		);
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 'no-secret', $response->data['code'] );
+		$this->assertEquals( 500, $response->status );
+
+	}
+
+	/**
+	 * Test that auth succeeds, but we still get an error for not enough info
+	 */
+	public function testAuthSuccess() {
+
+		$handler_obj = new Handler();
+		$handler_obj->register_rest_endpoint();
+
+		$request = new WP_REST_Request( 'PUT', '/' . Handler::API_NAMESPACE . '/' . Handler::ENDPOINT_RUN . '/test' );
+		$request->set_body(
+			wp_json_encode( [
+				'secret' => $this->secret,
+			] )
+		);
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 'rest-queue-invalid', $response->data['code'] );
+
+	}
+
+	/**
+	 * Test that a request goes through successfully if it has everything it needs
+	 */
+	public function testSuccessfullRequest() {
+
+		$handler_obj = new Handler();
+		$handler_obj->register_rest_endpoint();
+
+		$request = new WP_REST_Request( 'PUT', '/' . Handler::API_NAMESPACE . '/' . Handler::ENDPOINT_RUN . '/test' );
+		$request->set_body(
+			wp_json_encode( [
+				'secret' => $this->secret,
+				'term_id' => 123,
+			] )
+		);
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 'test queue processed', $response->data );
+		$this->assertEquals( 200, $response->status );
+
+	}
+
+	/**
+	 * Test to make sure the processor runs correctly in the REST request
+	 */
+	public function testSuccessfulQueueProcess() {
+
+		$processor_obj = new \WPQueueTasks\Processor();
+		$processor_obj->setup();
+
+		$handler_obj = new Handler();
+		$handler_obj->register_rest_endpoint();
+
+		$queue = 'testSuccessfulQueueProcess';
+		$key = '_test_' . $queue;
+		$data = 'some data here';
+
+		wpqt_register_queue( $queue, [
+			'callback' => function( $data ) use ( $key ) {
+				update_option( $key, $data, false );
+				return true;
+			},
+			'bulk' => false,
+		] );
+
+		$task_id = wpqt_create_task( $queue, $data );
+		$queue_id = get_term_by( 'name', $queue, 'task-queue' );
+
+		$request = new WP_REST_Request( 'PUT', '/' . Handler::API_NAMESPACE . '/' . Handler::ENDPOINT_RUN . '/' . $queue );
+		$request->set_body(
+			wp_json_encode( [
+				'secret' => $this->secret,
+				'term_id' => $queue_id->term_id,
+			] )
+		);
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( $queue . ' queue processed', $response->data );
+		$this->assertEquals( 200, $response->status );
+		$this->assertEquals( $data, get_option( $key ) );
+		$this->assertNull( get_post( $task_id ) );
+
+	}
+
+}

--- a/tests/src/test-Processor.php
+++ b/tests/src/test-Processor.php
@@ -14,38 +14,7 @@ class TestProcessor extends WP_UnitTestCase {
 
 		$processor_obj = new Processor();
 		$processor_obj->setup();
-		$this->assertEquals( 10, has_action( 'init', [ $processor_obj, 'setup_processing' ] ) );
 		$this->assertEquals( 10, has_action( 'wpqt_run_processor', [ $processor_obj, 'run_processor' ] ) );
-
-	}
-
-	/**
-	 * Test that the hook fires correctly for the async handler
-	 */
-	public function testProcessQueueFromAsyncHandler() {
-
-		$expected = [
-			'queue_name' => 'testProcessQueueFromAsyncHandler',
-			'term_id' => 1,
-		];
-
-		$_POST['queue_name'] = $expected['queue_name'];
-		$_POST['term_id'] = $expected['term_id'];
-
-		add_action( 'wpqt_run_processor', function( $queue_name, $term_id ) {
-			global $_test_wpqt_run_processor_data;
-			$_test_wpqt_run_processor_data = [
-				'queue_name' => $queue_name,
-				'term_id' => $term_id,
-			];
-		}, 10, 2 );
-
-		$processor_obj = new Processor();
-		$processor_obj->process_queue();
-
-		global $_test_wpqt_run_processor_data;
-
-		$this->assertEquals( $expected, $_test_wpqt_run_processor_data );
 
 	}
 
@@ -68,24 +37,6 @@ class TestProcessor extends WP_UnitTestCase {
 		$processor_obj = new Processor();
 		$actual = $processor_obj->run_processor( 'sometest', 2 );
 		$this->assertFalse( $actual );
-
-	}
-
-	/**
-	 * Test to make sure the proper hooks are added for handling async requests only when the queue
-	 * is using that as the processor
-	 */
-	public function testProcessingSetup() {
-
-		$queue = 'testProcessingSetup';
-		wpqt_register_queue( $queue, [ 'callback' => '__return_true' ] );
-		wpqt_register_queue( 'someOtherQueue', [ 'callback' => '__return_true', 'processor' => 'cron' ] );
-
-		$processor_obj = new Processor();
-		$processor_obj->setup_processing();
-
-		$this->assertTrue( has_action( 'admin_post_nopriv_wpqt_process_' . $queue ) );
-		$this->assertFalse( has_action( 'admin_post_nopriv_wpgt_process_someOtherQueue' ) );
 
 	}
 

--- a/tests/src/test-Scheduler.php
+++ b/tests/src/test-Scheduler.php
@@ -129,6 +129,34 @@ class TestScheduler extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Run a test in a separate process with a clean scope that doesn't have the
+	 * WPQT_PROCESSOR_SECRET constant defined, so we can make sure it doesn't post to the async
+	 * handler
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testNoSecretDefinedFailure() {
+
+		$queue = 'testNoSecretDefinedFailure';
+		wpqt_register_queue( $queue, [ 'callback' => '__return_true' ] );
+		wpqt_create_task( $queue, 'test' );
+
+		add_action( 'http_api_debug', function( $response ) {
+			global $test_request_response;
+			$test_request_response = $response;
+		} );
+
+		$scheduler_obj = new Scheduler();
+		$scheduler_obj->process_queue();
+
+		global $test_request_response;
+
+		$this->assertEmpty( $test_request_response );
+
+	}
+
+	/**
 	 * Tests to make sure that a processor doesn't run too frequently
 	 */
 	public function testProcessorSkipsQueueNotTimeToRun() {

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -6,6 +6,7 @@ $vendorDir = dirname(dirname(__FILE__));
 $baseDir = dirname($vendorDir);
 
 return array(
+    'WPQueueTasks\\Handler' => $baseDir . '/src/Handler.php',
     'WPQueueTasks\\Processor' => $baseDir . '/src/Processor.php',
     'WPQueueTasks\\Register' => $baseDir . '/src/Register.php',
     'WPQueueTasks\\Scheduler' => $baseDir . '/src/Scheduler.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -21,6 +21,7 @@ class ComposerStaticInit44247df0bc4adc251c446ae1642f8928
     );
 
     public static $classMap = array (
+        'WPQueueTasks\\Handler' => __DIR__ . '/../..' . '/src/Handler.php',
         'WPQueueTasks\\Processor' => __DIR__ . '/../..' . '/src/Processor.php',
         'WPQueueTasks\\Register' => __DIR__ . '/../..' . '/src/Register.php',
         'WPQueueTasks\\Scheduler' => __DIR__ . '/../..' . '/src/Scheduler.php',

--- a/wp-queue-tasks.php
+++ b/wp-queue-tasks.php
@@ -128,6 +128,9 @@ if ( ! class_exists( 'WPQueueTasks' ) ) {
 			$scheduler = new \WPQueueTasks\Scheduler();
 			$scheduler->setup();
 
+			$handler = new \WPQueueTasks\Handler();
+			$handler->setup();
+
 		}
 
 	}


### PR DESCRIPTION
This switches the async processor to use a rest endpoint rather than the weird thing we were doing before. Also includes tests! 🎉 

Also, in the first commit of this I moved the tmp dir for tests since it was getting all wonky for me locally.